### PR TITLE
oracle-linux-image-tools: Misc changes/fixes for OL8U4

### DIFF
--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -16,7 +16,7 @@ ROOT_FS="xfs"
 
 # Boot command
 # Variables MUST be escaped as they are evaluated at build time.
-BOOT_COMMAND='<up><tab>${CONSOLE} text ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>'
+BOOT_COMMAND='<up><tab>${CONSOLE} inst.text inst.ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>'
 
 # Kernel: uek, rhck
 KERNEL="uek"

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -29,6 +29,12 @@ KERNEL="uek"
 # machine-id differs between image build and deployed VM.
 RESCUE_KERNEL="no"
 
+# Authselect: default is set to "minimal" which should cover most use cases.
+# If an alternative auth profile is needed it can be specified with the
+# AUTHSELECT parameter, e.g.:
+# AUTHSELECT="select sssd"
+AUTHSELECT=""
+
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
 

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -66,6 +66,11 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
   # Pass kernel and rescue kernel selections
   sed -i -e 's!^KERNEL=.*$!KERNEL='"${KERNEL}"'!' "${ks_file}"
   sed -i -e 's!^RESCUE_KERNEL=.*$!RESCUE_KERNEL='"${RESCUE_KERNEL}"'!' "${ks_file}"
+
+  # Override authselect if needed
+  if [[ -n ${AUTHSELECT} ]]; then
+    sed -i -e 's!^authselect .*$!authselect '"${AUTHSELECT}"'!' "${ks_file}"
+  fi
 }
 
 #######################################

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -1,6 +1,6 @@
 # OL8 kickstart file
 # System authorization information
-auth --enableshadow --passalgo=sha512
+authselect select minimal with-faillock with-silent-lastlog with-pamaccess
 
 # Command line install
 cmdline

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -133,6 +133,12 @@ distr::common_cfg() {
     dnf update --security -y
   fi
 
+  # SSSD profile needs clients
+  if authselect current -r | grep -q '^sssd'; then
+    echo_message "Installing SSSD client"
+    dnf install -y sssd-client
+  fi
+
   # If you want to remove rsyslog and just use journald, remove this!
   echo_message "Disabling persistent journal"
   rm -rf /var/log/journal/

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -102,6 +102,13 @@ distr::kernel_config() {
     fi
   done
 
+  # Workaround for orabug 32816428
+  if [[ "${KERNEL,,}" = "uek" && -f "/etc/ld.so.conf.d/kernel-${current_kernel}.conf" ]]; then
+    cat > "/etc/ld.so.conf.d/kernel-${current_kernel}.conf" <<-EOF
+			# Placeholder file, no vDSO hwcap entries used in this kernel."
+			EOF
+  fi
+
   # Regenerate initrd
   ${DRACUT_CMD} -f "/boot/initramfs-${current_kernel}.img" "${current_kernel}"
 

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -342,7 +342,7 @@ distr::cleanup() {
   echo_message "Relabel SELinux"
   genhomedircon
   fixfiles -f -F relabel
-  restorecon -R /
+  restorecon -R / || true
   history -c
   swapoff -a
 }


### PR DESCRIPTION
#### New Features

* (olit): :sparkles: allow auth scheme selection for ol8
#### Fixes

* (olit): :bug: no vDSO hwcap for ol8/uek6
* (olit): :bug: use autheselect minimal profile.
* (olit): :bug: restorecon might have a non-zero return code
#### Refactorings

* (olit): :rotating_light: update ol8 ks boot command

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>