### PR TITLE
refactor(olit): :boom: use HCL2 for packer template

### DIFF
--- a/oracle-linux-image-tools/README.md
+++ b/oracle-linux-image-tools/README.md
@@ -74,7 +74,7 @@ The build script requires a Linux environment and has been tested on Oracle Linu
     - `ISO_URL`: location of the Oracle Linux distribution ISO
     - `ISO_CHECKSUM`: checksum for the ISO file. As from packer 1.6.0, you can prepend the checksum type (see [packer documentation](https://www.packer.io/docs/builders/virtualbox/iso#iso_checksum))
     - `CLOUD`: cloud target (azure, oci, olvm, ovm or none)
-    - `PACKER_BUILDER`: builder used by packer (virtualbox-iso or qemu)
+    - `PACKER_BUILDER`: builder used by packer (virtualbox-iso.x86-64 or qemu.x86-64)
 1. Run the builder:  
   `./bin/build-image.sh --env ENV_PROPERTY_FILE`
 

--- a/oracle-linux-image-tools/cloud/none/image-scripts.sh
+++ b/oracle-linux-image-tools/cloud/none/image-scripts.sh
@@ -42,7 +42,7 @@ cloud::image_cleanup() {
 #   None
 #######################################
 cloud::image_package() {
-  if [[ ${PACKER_BUILDER} = "virtualbox-iso" ]]; then
+  if [[ ${PACKER_BUILDER} = "virtualbox-iso.x86-64" ]]; then
     local vmdk
     vmdk=$(grep "ovf:href" "${VM_NAME}.ovf" | sed -r -e 's/.*ovf:href="([^"]+)".*/\1/')
     vboxmanage convertfromraw System.img --format VMDK "${vmdk}" --variant Stream

--- a/oracle-linux-image-tools/cloud/vagrant-virtualbox/image-scripts.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-virtualbox/image-scripts.sh
@@ -44,15 +44,10 @@ cloud::validate() {
 #######################################
 cloud::packer_conf() {
   if [[ -n "${VAGRANT_GUEST_ADDITIONS_URL}" && -n "${VAGRANT_GUEST_ADDITIONS_SHA256}" ]]; then
-    ex -s "$1" <<-EOF
-	/"disk_size": /
-	:append
-	      "guest_additions_url": "${VAGRANT_GUEST_ADDITIONS_URL}",
-	      "guest_additions_sha256": "${VAGRANT_GUEST_ADDITIONS_SHA256}",
-	.
-	:update
-	:quit
-	EOF
+    cat >>"$1" <<-EOF
+			guest_additions_url    = "${VAGRANT_GUEST_ADDITIONS_URL}"
+			guest_additions_sha256 = "${VAGRANT_GUEST_ADDITIONS_SHA256}"
+		EOF
   fi
 }
 

--- a/oracle-linux-image-tools/distr/ol7-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol7-slim/env.properties
@@ -16,7 +16,7 @@ ROOT_FS="xfs"
 
 # Boot command
 # Variables MUST be escaped as they are evaluated at build time.
-BOOT_COMMAND='<up><tab>${CONSOLE} text ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>'
+BOOT_COMMAND=( '<up><tab>${CONSOLE} text ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>' )
 
 # Kernel: uek, rhck or modrhck
 KERNEL="uek"

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -16,7 +16,7 @@ ROOT_FS="xfs"
 
 # Boot command
 # Variables MUST be escaped as they are evaluated at build time.
-BOOT_COMMAND='<up><tab>${CONSOLE} inst.text inst.ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>'
+BOOT_COMMAND=( '<up><tab>${CONSOLE} inst.text inst.ks=${KS_CONFIG} setup_swap=${SETUP_SWAP} <enter>' )
 
 # Kernel: uek, rhck
 KERNEL="uek"

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -75,9 +75,9 @@ CLOUD="none"
 # We use the full path for Hashicorp Packer from the Linux package generating tool
 # PACKER="/usr/bin/packer"
 # PACKER_BUILD_OPTIONS="-on-error=ask"
-# Packer builder (virtualbox-iso or qemu)
-# Vagrant virtualbox images require virtualbox-iso builder
-# PACKER_BUILDER="virtualbox-iso"
+# Packer builder (virtualbox-iso.x86-64 or qemu.x86-64)
+# Vagrant virtualbox images require virtualbox-iso.x86-64 builder
+# PACKER_BUILDER="virtualbox-iso.x86-64"
 # Location of the QEMU binary
 # QEMU_BINARY=""
 

--- a/oracle-linux-image-tools/env.properties.defaults
+++ b/oracle-linux-image-tools/env.properties.defaults
@@ -40,9 +40,9 @@ SERIAL_CONSOLE="no"
 PACKER="/usr/bin/packer"
 PACKER_BUILD_OPTIONS="-on-error=ask"
 
-# Packer builder (virtualbox-iso or qemu)
-# Vagrant virtualbox images require virtualbox-iso builder
-PACKER_BUILDER="virtualbox-iso"
+# Packer builder (virtualbox-iso.x86-64 or qemu.x86-64)
+# Vagrant virtualbox images require virtualbox-iso.x86-64 builder
+PACKER_BUILDER="virtualbox-iso.x86-64"
 # Location of the QEMU binary
 QEMU_BINARY=""
 

--- a/oracle-linux-image-tools/packer-template/build.pkr.hcl
+++ b/oracle-linux-image-tools/packer-template/build.pkr.hcl
@@ -1,0 +1,14 @@
+build {
+  sources = [
+    "virtualbox-iso.x86-64",
+    "qemu.x86-64",
+  ]
+  provisioner "file" {
+    source      = var.packer_files
+    destination = "/tmp"
+
+  }
+  provisioner "shell" {
+    script = var.provision_script
+  }
+}

--- a/oracle-linux-image-tools/packer-template/qemu-x86-64.pkr.hcl
+++ b/oracle-linux-image-tools/packer-template/qemu-x86-64.pkr.hcl
@@ -1,0 +1,27 @@
+# x86-64 build with qemu-kvm
+
+source "qemu" "x86-64" {
+  accelerator          = "kvm"
+  iso_url              = var.iso_url
+  iso_checksum         = var.iso_checksum
+  output_directory     = local.output_directory
+  vm_name              = "System.img"
+  net_device           = "virtio-net"
+  disk_interface       = "virtio-scsi"
+  disk_size            = var.disk_size
+  cpus                 = var.cpus
+  memory               = var.memory
+  format               = "raw"
+  headless             = "true"
+  ssh_username         = "root"
+  ssh_password         = var.ssh_password
+  ssh_private_key_file = var.ssh_private_key_file
+  ssh_port             = 22
+  ssh_wait_timeout     = "30m"
+  http_directory       = local.http_directory
+  boot_wait            = "20s"
+  boot_command         = var.boot_command
+  shutdown_command     = var.shutdown_command
+  qemu_binary          = var.qemu_binary
+  qemuargs             = var.qemu_args
+}

--- a/oracle-linux-image-tools/packer-template/variables.pkr.hcl
+++ b/oracle-linux-image-tools/packer-template/variables.pkr.hcl
@@ -1,0 +1,115 @@
+# Variables and locals declaration
+
+# Environment
+variable "workspace" {
+  description = "Workspace directory"
+  type        = string
+}
+
+variable "packer_files" {
+  description = "Directory for the provisioning files"
+  type        = string
+}
+
+variable "provision_script" {
+  description = "Provisioning script"
+  type        = string
+}
+
+# ISO
+variable "iso_url" {
+  description = "URL of the ISO"
+  type        = string
+}
+
+variable "iso_checksum" {
+  description = "Checksum of the ISO"
+  type        = string
+}
+
+# Generic VM properties
+variable "vm_name" {
+  description = "Name of the VM"
+  type        = string
+}
+
+variable "disk_size" {
+  description = "Disk size for the VM in MB"
+  type        = number
+}
+
+variable "memory" {
+  description = "Memory for the VM in MB"
+  type        = number
+}
+
+variable "cpus" {
+  description = "Number of CPUs for the VM in MB"
+  type        = number
+}
+
+variable "ssh_password" {
+  description = "Password for the root user"
+  type        = string
+  default     = null
+}
+
+variable "ssh_private_key_file" {
+  description = "SSH private key file for the root user"
+  type        = string
+  default     = null
+}
+
+variable "boot_command" {
+  description = "Boot command"
+  type        = list(string)
+}
+
+variable "shutdown_command" {
+  description = "shutdown_command"
+  type        = string
+}
+
+# VirtualBox properties
+variable "guest_additions_url" {
+  description = "URL of the VirtualBox Guest Additions"
+  type        = string
+  default     = null
+}
+
+variable "guest_additions_sha256" {
+  description = "Checksum of the VirtualBox Guest Additions"
+  type        = string
+  default     = null
+}
+
+variable "vbox_manage" {
+  description = "VirtualBox vboxmanage aditional stanzas (for the serial console)"
+  type        = list(list(string))
+  default     = []
+}
+
+variable "x2apic" {
+  description = "X2APIC for VirtualBox"
+  type        = string
+  default     = "on"
+}
+
+# QEMU properties
+variable "qemu_binary" {
+  description = "QEMU binary"
+  type        = string
+  default     = null
+}
+
+variable "qemu_args" {
+  description = "QEMU Arguments"
+  type        = list(list(string))
+  default     = []
+}
+
+# Locals
+locals {
+  output_directory = "${var.workspace}/${var.vm_name}"
+  http_directory   = var.workspace
+}

--- a/oracle-linux-image-tools/packer-template/virtualbox-x86-64.pkr.hcl
+++ b/oracle-linux-image-tools/packer-template/virtualbox-x86-64.pkr.hcl
@@ -1,0 +1,37 @@
+# x86-64 build with VirtualBox
+
+source "virtualbox-iso" "x86-64" {
+  guest_os_type          = "Oracle_64"
+  iso_url                = var.iso_url
+  iso_checksum           = var.iso_checksum
+  output_directory       = local.output_directory
+  vm_name                = var.vm_name
+  hard_drive_interface   = "sata"
+  disk_size              = var.disk_size
+  guest_additions_mode   = "attach"
+  guest_additions_url    = var.guest_additions_url
+  guest_additions_sha256 = var.guest_additions_sha256
+  format                 = "ova"
+  headless               = "true"
+  ssh_username           = "root"
+  ssh_password           = var.ssh_password
+  ssh_private_key_file   = var.ssh_private_key_file
+  ssh_port               = 22
+  ssh_wait_timeout       = "30m"
+  http_directory         = local.http_directory
+  boot_wait              = "20s"
+  boot_command           = var.boot_command
+  shutdown_command       = var.shutdown_command
+  vboxmanage = concat(
+    var.vbox_manage,
+    [
+      ["modifyvm", "{{.Name}}", "--x2apic", var.x2apic],
+      ["modifyvm", "{{.Name}}", "--memory", var.memory],
+      ["modifyvm", "{{.Name}}", "--cpus", var.cpus],
+    ]
+  )
+  vboxmanage_post = [
+    ["modifyvm", "{{.Name}}", "--uart1", "off", "--uartmode1", "disconnected"],
+    ["modifyvm", "{{.Name}}", "--x2apic", "on"],
+  ]
+}


### PR DESCRIPTION
Migrated from JSON to HCL2 packer templates as HCL2 is now the preferred template format for packer.

This introduce minor breaking changes for existing configurations:
- BOOT_COMMAND variable is now a bash array
- packer_conf() hooks can only change the generated pkrvars.hcl file

Tested on Vagrant boxes and OLVM/KVM templates.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>