### PR TITLE
Misc updates for OL8U5 release

### DIFF
--- a/oracle-linux-image-tools/distr/ol7-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol7-slim/env.properties
@@ -3,7 +3,7 @@
 # env file.
 
 # Distribution name
-DISTR_NAME="OL7U8_x86_64"
+DISTR_NAME="OL7U9_x86_64"
 
 # Distribution release
 readonly ORACLE_RELEASE=7

--- a/oracle-linux-image-tools/distr/ol8-aarch64/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-aarch64/env.properties
@@ -3,7 +3,7 @@
 # env file.
 
 # Distribution name
-DISTR_NAME="OL8U4_aarch64"
+DISTR_NAME="OL8U5_aarch64"
 
 # Distribution release
 readonly ORACLE_RELEASE=8
@@ -15,7 +15,7 @@ SETUP_SWAP="yes"
 ROOT_FS="xfs"
 
 # Label of the ISO image
-ISO_LABEL="OL-8-4-0-BaseOS-aarch64"
+ISO_LABEL="OL-8-5-0-BaseOS-aarch64"
 
 # Boot command
 # Variables MUST be escaped as they are evaluated at build time.

--- a/oracle-linux-image-tools/distr/ol8-aarch64/ol8-aarch64-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-aarch64/ol8-aarch64-ks.cfg
@@ -100,6 +100,10 @@ part /        --fstype="xfs"  --ondisk=sda --size=4096 --label=root  --grow
 # hwdata blacklists several modules, a.o. the fb (frame buffer) ones
 hwdata
 
+# Create a generic image
+dracut-config-generic
+cloud-utils-growpart
+
 # Guest agent is missing when build in emulated tcg mode
 qemu-guest-agent
 

--- a/oracle-linux-image-tools/distr/ol8-aarch64/ol8-aarch64-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-aarch64/ol8-aarch64-ks.cfg
@@ -216,3 +216,6 @@ else
 fi
 
 %end
+
+%addon com_redhat_kdump --disable
+%end

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -3,7 +3,7 @@
 # env file.
 
 # Distribution name
-DISTR_NAME="OL8U2_x86_64"
+DISTR_NAME="OL8U5_x86_64"
 
 # Distribution release
 readonly ORACLE_RELEASE=8

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -191,3 +191,6 @@ else
 fi
 
 %end
+
+%addon com_redhat_kdump --disable
+%end


### PR DESCRIPTION
#### New Features

* (olit): :sparkles: aarch64 - make generic image.
* (olit): :sparkles: don't generate kdump initrd

#### Others

* (olit): :speech_balloon: default DISTR_NAME to latest release
