### PR TITLE
build(olit): increase aarch64 wait timeout.

### DIFF
--- a/oracle-linux-image-tools/packer-template/qemu-aarch64.pkr.hcl
+++ b/oracle-linux-image-tools/packer-template/qemu-aarch64.pkr.hcl
@@ -44,7 +44,7 @@ source "qemu" "aarch64" {
   ssh_password         = var.ssh_password
   ssh_private_key_file = var.ssh_private_key_file
   ssh_port             = 22
-  ssh_wait_timeout     = "90m"
+  ssh_wait_timeout     = "120m"
   http_directory       = local.http_directory
   boot_wait            = "20s"
   boot_command         = var.boot_command


### PR DESCRIPTION
Avoid timeouts when aarch64 build runs in qemu tcg mode (emulated).

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>