### PR TITLE
feat(olit): add options to reduce image size.

### DIFF
--- a/oracle-linux-image-tools/distr/ol7-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol7-slim/env.properties
@@ -27,5 +27,23 @@ UEK_RELEASE=6
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
 
+# Keep linux-firmware package? yes, no
+# Linux firmware is not needed on VM instances.
+# Note that kernel packages have an install dependency on linux-firmware; if
+# removed it will be re-installed when a new kernel is installed.
+LINUX_FIRMWARE="yes"
+
+# Strip locales to only keep en_US? yes, no
+STRIP_LOCALES="no"
+
+# Exclude documentation (man pages, info files, doc files)? yes, no, minimal
+# When "yes" is selected, yum wil be configured to exclude all documentation
+# ("tsflags=nodocs" parameter).
+# If you plan to re-distribute the image, you might need to keep the
+# "/usr/share/doc" directory which contains the packages licence terms.
+# The "minimal" option will remove man pages and info files, but will keep the
+# "/usr/share/doc" directory.
+EXCLUDE_DOCS="no"
+
 # Directory used to save build information
 readonly BUILD_INFO="/.build-info"

--- a/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol7-slim/image-scripts.sh
@@ -2,7 +2,7 @@
 #
 # image scripts for OL7
 #
-# Copyright (c) 2019,2020 Oracle and/or its affiliates.
+# Copyright (c) 2019,2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl
 #
@@ -23,10 +23,12 @@
 #   None
 #######################################
 distr::validate() {
-[[ "${ROOT_FS,,}" =~ ^(xfs)|(btrfs)|(lvm)$ ]] || error "ROOT_FS must be xfs, btrfs or lvm"
-  readonly ROOT_FS
+  [[ "${ROOT_FS,,}" =~ ^(xfs)|(btrfs)|(lvm)$ ]] || error "ROOT_FS must be xfs, btrfs or lvm"
   [[ "${UEK_RELEASE}" =~ ^[56]$ ]] || error "UEK_RELEASE must be 5 or 6"
-    readonly UEK_RELEASE
+  [[ "${LINUX_FIRMWARE,,}" =~ ^(yes)|(no)$ ]] || error "LINUX_FIRMWARE must be yes or no"
+  [[ "${STRIP_LOCALES,,}" =~ ^(yes)|(no)$ ]] || error "STRIP_LOCALES must be yes or no"
+  [[ "${EXCLUDE_DOCS,,}" =~ ^(yes)|(no)|(minimal)$ ]] || error "EXCLUDE_DOCS must be yes, no or minimal"
+  readonly ROOT_FS UEK_RELEASE LINUX_FIRMWARE STRIP_LOCALES EXCLUDE_DOCS
 }
 
 #######################################
@@ -64,6 +66,15 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
   # Pass kernel selection
   sed -i -e 's!^KERNEL=.*$!KERNEL='"${KERNEL}"'!' "${ks_file}"
   sed -i -e 's!^UEK_RELEASE=.*$!UEK_RELEASE='"${UEK_RELEASE}"'!' "${ks_file}"
+
+  # Locale
+  sed -i -e 's!^STRIP_LOCALES=.*$!STRIP_LOCALES='"${STRIP_LOCALES}"'!' "${ks_file}"
+
+  # Docs
+  sed -i -e 's!^EXCLUDE_DOCS=.*$!EXCLUDE_DOCS='"${EXCLUDE_DOCS}"'!' "${ks_file}"
+  if [[ "${EXCLUDE_DOCS,,}" = "yes" ]]; then
+    sed -i -e 's!^%packages !%packages --excludedocs !' "${ks_file}"
+  fi
 }
 
 #######################################

--- a/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol7-slim/ol7-ks.cfg
@@ -187,6 +187,26 @@ sed -i \
   /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+EXCLUDE_DOCS="no"
+echo "Exclude documentation: ${EXCLUDE_DOCS^^}"
+if [[ "${EXCLUDE_DOCS,,}" = "yes" ]]; then 
+  echo "tsflags=nodocs" >> /etc/yum.conf
+fi
+
+STRIP_LOCALES="no"
+echo "Strip locales: ${STRIP_LOCALES^^}"
+if [[ "${STRIP_LOCALES,,}" = "yes" ]]; then 
+  localedef --list-archive |
+    grep -E -v '^C|^en_US' |
+    xargs localedef --delete-from-archive
+  # this will kill a live system (since it's memory mapped) but should be
+  # safe offline
+  mv -f /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
+  build-locale-archive
+  # prevent further installation of non-en_US locales
+  echo '%_install_langs C:en_US' >> /etc/rpm/macros.image-language-conf
+fi
+
 # Install latest kernel, that way it will be available at first boot and
 # allow proper cleanup
 KERNEL=uek

--- a/oracle-linux-image-tools/distr/ol8-aarch64/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-aarch64/env.properties
@@ -48,5 +48,20 @@ AUTHSELECT=""
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
 
+# Keep linux-firmware package? yes, no
+# Linux firmware is not needed on VM instances.
+# Note that kernel packages have an install dependency on linux-firmware; if
+# removed it will be re-installed when a new kernel is installed.
+LINUX_FIRMWARE="yes"
+
+# Exclude documentation (man pages, info files, doc files)? yes, no, minimal
+# When "yes" is selected, dnf wil be configured to exclude all documentation
+# ("tsflags=nodocs" parameter).
+# If you plan to re-distribute the image, you might need to keep the
+# "/usr/share/doc" directory which contains the packages licence terms.
+# The "minimal" option will remove man pages and info files, but will keep the
+# "/usr/share/doc" directory.
+EXCLUDE_DOCS="no"
+
 # Directory used to save build information
 readonly BUILD_INFO="/.build-info"

--- a/oracle-linux-image-tools/distr/ol8-aarch64/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-aarch64/image-scripts.sh
@@ -2,7 +2,7 @@
 #
 # image scripts for OL8 - aarch64
 #
-# Copyright (c) 2021 Oracle and/or its affiliates.
+# Copyright (c) 2021,2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl
 #
@@ -28,8 +28,10 @@ distr::validate() {
   [[ "${ROOT_FS,,}" =~ ^(xfs)|(btrfs)|(lvm)$ ]] || error "ROOT_FS must be xfs, btrfs or lvm"
   [[ "${ROOT_FS,,}" = "btrfs" ]] && echo_message "Note that for btrfs root filesystem you need to use an UEK boot ISO"
   [[ "${RESCUE_KERNEL,,}" =~ ^(yes)|(no)$ ]] || error "RESCUE_KERNEL must be yes or no"
-  readonly RESCUE_KERNEL ROOT_FS
   [[ -n ${ISO_LABEL} ]] || error "ISO_LABEL must be provided"
+  [[ "${LINUX_FIRMWARE,,}" =~ ^(yes)|(no)$ ]] || error "LINUX_FIRMWARE must be yes or no"
+  [[ "${EXCLUDE_DOCS,,}" =~ ^(yes)|(no)|(minimal)$ ]] || error "EXCLUDE_DOCS must be yes, no or minimal"
+  readonly ROOT_FS RESCUE_KERNEL ISO_LABEL LINUX_FIRMWARE EXCLUDE_DOCS
 }
 
 #######################################
@@ -89,6 +91,12 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
   # Override authselect if needed
   if [[ -n ${AUTHSELECT} ]]; then
     sed -i -e 's!^authselect .*$!authselect '"${AUTHSELECT}"'!' "${ks_file}"
+  fi
+
+  # Docs
+  sed -i -e 's!^EXCLUDE_DOCS=.*$!EXCLUDE_DOCS='"${EXCLUDE_DOCS}"'!' "${ks_file}"
+  if [[ "${EXCLUDE_DOCS,,}" = "yes" ]]; then
+    sed -i -e 's!^%packages!%packages --excludedocs!' "${ks_file}"
   fi
 }
 

--- a/oracle-linux-image-tools/distr/ol8-aarch64/ol8-aarch64-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-aarch64/ol8-aarch64-ks.cfg
@@ -187,6 +187,12 @@ if [[ "${RESCUE_KERNEL,,}" = "no" ]]; then
   rm -f /boot/loader/entries/$(cat /etc/machine-id)-0-rescue.conf
 fi
 
+EXCLUDE_DOCS="no"
+echo "Exclude documentation: ${EXCLUDE_DOCS^^}"
+if [[ "${EXCLUDE_DOCS,,}" = "yes" ]]; then 
+  echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
+fi
+
 # Get latest release file
 dnf upgrade -y oraclelinux-release-el8
 

--- a/oracle-linux-image-tools/distr/ol8-slim/env.properties
+++ b/oracle-linux-image-tools/distr/ol8-slim/env.properties
@@ -38,5 +38,20 @@ AUTHSELECT=""
 # Update: yes, security, no
 UPDATE_TO_LATEST="yes"
 
+# Keep linux-firmware package? yes, no
+# Linux firmware is not needed on VM instances.
+# Note that kernel packages have an install dependency on linux-firmware; if
+# removed it will be re-installed when a new kernel is installed.
+LINUX_FIRMWARE="yes"
+
+# Exclude documentation (man pages, info files, doc files)? yes, no, minimal
+# When "yes" is selected, dnf wil be configured to exclude all documentation
+# ("tsflags=nodocs" parameter).
+# If you plan to re-distribute the image, you might need to keep the
+# "/usr/share/doc" directory which contains the packages licence terms.
+# The "minimal" option will remove man pages and info files, but will keep the
+# "/usr/share/doc" directory.
+EXCLUDE_DOCS="no"
+
 # Directory used to save build information
 readonly BUILD_INFO="/.build-info"

--- a/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/image-scripts.sh
@@ -2,7 +2,7 @@
 #
 # image scripts for OL8
 #
-# Copyright (c) 2020 Oracle and/or its affiliates.
+# Copyright (c) 2020,2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl
 #
@@ -28,7 +28,9 @@ distr::validate() {
   [[ "${ROOT_FS,,}" =~ ^(xfs)|(btrfs)|(lvm)$ ]] || error "ROOT_FS must be xfs, btrfs or lvm"
   [[ "${ROOT_FS,,}" = "btrfs" ]] && echo_message "Note that for btrfs root filesystem you need to use an UEK boot ISO"
   [[ "${RESCUE_KERNEL,,}" =~ ^(yes)|(no)$ ]] || error "RESCUE_KERNEL must be yes or no"
-  readonly RESCUE_KERNEL ROOT_FS
+  [[ "${LINUX_FIRMWARE,,}" =~ ^(yes)|(no)$ ]] || error "LINUX_FIRMWARE must be yes or no"
+  [[ "${EXCLUDE_DOCS,,}" =~ ^(yes)|(no)|(minimal)$ ]] || error "EXCLUDE_DOCS must be yes, no or minimal"
+  readonly ROOT_FS RESCUE_KERNEL LINUX_FIRMWARE EXCLUDE_DOCS
 }
 
 #######################################
@@ -70,6 +72,12 @@ logvol /      --fstype=\"xfs\"  --vgname=vg_main --size=4096 --name=lv_root --gr
   # Override authselect if needed
   if [[ -n ${AUTHSELECT} ]]; then
     sed -i -e 's!^authselect .*$!authselect '"${AUTHSELECT}"'!' "${ks_file}"
+  fi
+
+  # Docs
+  sed -i -e 's!^EXCLUDE_DOCS=.*$!EXCLUDE_DOCS='"${EXCLUDE_DOCS}"'!' "${ks_file}"
+  if [[ "${EXCLUDE_DOCS,,}" = "yes" ]]; then
+    sed -i -e 's!^%packages!%packages --excludedocs!' "${ks_file}"
   fi
 }
 

--- a/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
+++ b/oracle-linux-image-tools/distr/ol8-slim/ol8-ks.cfg
@@ -153,6 +153,12 @@ sed -i \
   /etc/default/grub
 grub2-mkconfig -o /boot/grub2/grub.cfg
 
+EXCLUDE_DOCS="no"
+echo "Exclude documentation: ${EXCLUDE_DOCS^^}"
+if [[ "${EXCLUDE_DOCS,,}" = "yes" ]]; then 
+  echo "tsflags=nodocs" >> /etc/dnf/dnf.conf
+fi
+
 # Get latest release file (Needed for UEK)
 dnf upgrade -y oraclelinux-release-el8
 

--- a/oracle-linux-image-tools/distr/ol8-slim/provision.sh
+++ b/oracle-linux-image-tools/distr/ol8-slim/provision.sh
@@ -2,7 +2,7 @@
 #
 # Packer provisioning script for OL8
 #
-# Copyright (c) 2019,2020 Oracle and/or its affiliates.
+# Copyright (c) 2019,2022 Oracle and/or its affiliates.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl
 #
@@ -115,6 +115,11 @@ distr::kernel_config() {
   # Ensure grub is properly setup
   grub2-mkconfig -o /boot/grub2/grub.cfg
   grubby --set-default="/boot/vmlinuz-${current_kernel}"
+
+  echo_message "Linux firmware: ${LINUX_FIRMWARE^^}"
+  if [[ "${LINUX_FIRMWARE,,}" = "no" ]]; then
+    distr::remove_rpms linux-firmware
+  fi
 }
 
 #######################################
@@ -314,6 +319,15 @@ distr::cleanup() {
     [ -d /root/.ssh ] && /bin/rm -fr /root/.ssh
   else
     find /root/.ssh -type f -not -name authorized_keys -delete
+  fi
+
+  # Rebuild rpmdb to save some space
+  rpm --rebuilddb
+
+  # Remove man and info pages
+  echo_message "Exclude documentation: ${EXCLUDE_DOCS^^}"
+  if [[ "${EXCLUDE_DOCS,,}" = "minimal" ]]; then
+    rm -rf /usr/share/{man,info}
   fi
 
   # cleanup vnc cache files

--- a/oracle-linux-image-tools/env.properties
+++ b/oracle-linux-image-tools/env.properties
@@ -56,6 +56,28 @@ CLOUD="none"
 # UEK release (distribution / cloud specific)
 # UEK_RELEASE=
 
+# Keep linux-firmware package? (Yes/No, default Yes)
+# Linux firmware is not needed on VM instances, unless hardware like GPU is
+# directly passed to the VM.
+# Removing this package will drastically reduce the size of the image.
+# Note that kernel packages have an install dependency on linux-firmware; if
+# removed it will be re-installed when a new kernel is installed.
+# LINUX_FIRMWARE=
+
+# Strip locales and only keep en_US? (Yes/No, default No)
+# (ol7-slim ditribution only)
+# STRIP_LOCALES=
+
+# Exclude documentation (man pages, info files, doc files)? (Yes/No/Minimal,
+# default: No)
+# When "Yes" is selected, yum/dnf wil be configured to exclude all documentation
+# ("tsflags=nodocs" parameter).
+# If you plan to re-distribute the image, you might need to keep the
+# "/usr/share/doc" directory which contains the packages licence terms.
+# The "Minimal" option will remove man pages and info files, but will keep the
+# "/usr/share/doc" directory.
+# EXCLUDE_DOCS=
+
 # Number of CPUs for the build VM (Default: 4)
 # CPU_NUM=
 # Memory allocated to the build VM (Default: 8192)


### PR DESCRIPTION
This commit adds the following options which can be used to reduce the image size:

- LINUX_FIRMWARE: to remove the linux-firmware package from the image (about 300MB)
- STRIP_LOCALES: to remove the non en_US locales on ol7-slim image (about 50MB)
- EXCLUDE_DOCS: to remove or reduce the packages documentation (5-15MB)

For backward compatibility reason, none of these options are enable by default.

Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>