### PR TITLE
OL9 / Vagrant fixes

### DIFF
--- a/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
@@ -44,6 +44,12 @@ vagrant::config()
 		EOF
   fi
 
+  # For OL9 re-enable SHA1 as the vagrant embedded ssh client insists to use
+  # SHA1 for RSA keys -- See hashicorp/vagrant#12344
+  if [[ "${ORACLE_RELEASE}" = "9" ]]; then
+    /bin/update-crypto-policies --set DEFAULT:SHA1
+  fi
+
   cat >>/etc/sysconfig/sshd <<EOF
 
 # Decrease connection time by preventing reverse DNS lookups

--- a/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
+++ b/oracle-linux-image-tools/cloud/vagrant-virtualbox/files/vagrant-common.sh
@@ -93,9 +93,11 @@ EOF
   chcon -u system_u -r object_r -t modules_conf_t /etc/modprobe.d/nofloppy.conf
 
   # Customize the initramfs
-  # Enable VMware PVSCSI support for VMware Fusion guests.
-  echo 'add_drivers+=" mptspi "' > /etc/dracut.conf.d/vmware-fusion-drivers.conf
-  restorecon /etc/dracut.conf.d/vmware-fusion-drivers.conf
+  if [[ "${ORACLE_RELEASE}" != "9" ]]; then
+    # Enable VMware PVSCSI support for VMware Fusion guests.
+    echo 'add_drivers+=" mptspi "' > /etc/dracut.conf.d/vmware-fusion-drivers.conf
+    restorecon /etc/dracut.conf.d/vmware-fusion-drivers.conf
+  fi
   # There's no floppy controller, but probing for it generates timeouts
   echo 'omit_drivers+=" floppy "' > /etc/dracut.conf.d/nofloppy.conf
   restorecon /etc/dracut.conf.d/nofloppy.conf


### PR DESCRIPTION
#### Fixes

* (olss): :bug: vagrant/ol9 does not require mptspi
* (olss): :bug: enable sha-1 for vagrant/ol9.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>