### PR TITLE
fix(olss): :bug: cloud-init requires tar

### DIFF
--- a/oracle-linux-image-tools/CHANGELOG.md
+++ b/oracle-linux-image-tools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## March 30, 2024
+
+### Bug fixes
+
+- `cloud-init collect-logs` requires `tar`
+
 ## March, 2024
 
 Major refactoring of the scripts, reducing dependencies on third parties.

--- a/oracle-linux-image-tools/cloud/oci/provision.sh
+++ b/oracle-linux-image-tools/cloud/oci/provision.sh
@@ -81,7 +81,7 @@ cloud::cloud_init()
     #   image mounted!
     mkdir /etc/cloud
     touch /etc/cloud/cloud-init.disabled
-    yum install -y "${YUM_VERBOSE}" cloud-init cloud-utils-growpart
+    yum install -y "${YUM_VERBOSE}" cloud-init tar cloud-utils-growpart
     rm /etc/cloud/cloud-init.disabled
     cat > /etc/cloud/cloud.cfg.d/90_ol.cfg <<-EOF
 	# Provide sensible defaults for OL - see Orabug 34821447

--- a/oracle-linux-image-tools/cloud/olvm/provision.sh
+++ b/oracle-linux-image-tools/cloud/olvm/provision.sh
@@ -73,7 +73,7 @@ cloud::cloud_init()
     #   image mounted!
     mkdir /etc/cloud
     touch /etc/cloud/cloud-init.disabled
-    yum install -y "${YUM_VERBOSE}" cloud-init cloud-utils-growpart
+    yum install -y "${YUM_VERBOSE}" cloud-init tar cloud-utils-growpart
     rm /etc/cloud/cloud-init.disabled
     cat > /etc/cloud/cloud.cfg.d/90_ol.cfg <<-EOF
 	# Provide sensible defaults for OL - see Orabug 34821447


### PR DESCRIPTION
Fixes #134

OL KVM images have been refreshed for both x86_64 and aarch64

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>