### PR TITLE
fix(olss): :bug: osinfo-query sorts alphabetically.

### DIFF
--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -196,6 +196,7 @@ load_env() {
   if [[ -z ${OS_VARIANT} ]]; then
     OS_VARIANT=$(osinfo-query os --fields=short-id vendor="Oracle America" |
       grep "ol${ORACLE_RELEASE}\." |
+      sort -V |
       tail -1 |
       sed -e 's/ //g')
   fi


### PR DESCRIPTION
Use a version-based sort on the output of osinfo-query to ensure we always use the latest available variant when creating the initial VM.

Credit to Andy West for spotting this issue and proposing a fix.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>
