### PR TITLE
Fix ISO_LABEL handling and symlink resolution in ISO detection

### DIFF
--- a/oracle-linux-image-tools/bin/build-image.sh
+++ b/oracle-linux-image-tools/bin/build-image.sh
@@ -367,10 +367,9 @@ stage_kickstart() {
 image_create() {
   common::echo_header "Install Oracle Linux"
 
-  # retrieve disk label -- alternatively: isoinfo -d -i
-  local ISO_LABEL
-  # shellcheck disable=SC2034,SC2153
-  ISO_LABEL=$(file "${ISO_PATH}" | sed -e "s/.* '\(.*\)' .*/\1/"  -e 's/ /\\x20/g')
+  # retrieve disk label
+  # shellcheck disable=SC2034
+  ISO_LABEL="${ISO_LABEL:-$(file -L "${ISO_PATH}" | sed -e "s/.* '\(.*\)' .*/\1/" -e 's/ /\\x20/g')}"
 
   declare -ga virt_install_args
   # Set Serial console


### PR DESCRIPTION
- Declaring 'local ISO_LABEL' inside a function was shadowing the global environment variable defined in env.properties. This caused unexpected behavior during ISO processing.

- When ISO_URL is set to a 'file://' path, a symlink is created in '.cache'. The 'file "${ISO_PATH}"' command was resolving the symlink itself, which interfered with sed processing.

- Replaced 'file "${ISO_PATH}"' with 'file -L "${ISO_PATH}"' to follow symlinks and ensure consistent behavior.